### PR TITLE
Added RECEIVE_PRESCREEN_APPLICATION_RESULT type

### DIFF
--- a/Sources/BreadPartnersSDK/HTMLHandling/UIComponents/BreadFinancialWebViewInterstitial.swift
+++ b/Sources/BreadPartnersSDK/HTMLHandling/UIComponents/BreadFinancialWebViewInterstitial.swift
@@ -144,6 +144,12 @@ internal class BreadFinancialWebViewInterstitial: NSObject,
                     callback(.webViewSuccess(result: payload))
                 }
                 
+            case "RECEIVE_PRESCREEN_APPLICATION_RESULT":
+                if let payload = action["payload"] as? [String: Any] {
+                    logger.logApplicationResultDetails(payload)
+                    callback(.webViewSuccess(result: payload))
+                }
+                
             case "APPLICATION_COMPLETED":
                 callback(.screenName(name: "application-completed"))
                 callback(.popupClosed)


### PR DESCRIPTION
WebView returned event with that type when application was successfully finished in RTPS flow. Because it was not handled before, SDK did not return WebViewSuccess event when user finished application flow. Adding it fixes the issue. 