### PR TITLE
Fix captcha interruption issue

### DIFF
--- a/Sources/BreadPartnersSDK/BreadPartnersSDK.swift
+++ b/Sources/BreadPartnersSDK/BreadPartnersSDK.swift
@@ -101,7 +101,6 @@ public class BreadPartnersSDK: NSObject, UITextViewDelegate {
         placementsConfiguration: PlacementConfiguration,
         splitTextAndAction: Bool = false,
         forSwiftUI: Bool = false,
-        showCaptcha: Bool = false,
         callback: @Sendable @escaping (
             BreadPartnerEvents
         ) -> Void
@@ -126,7 +125,6 @@ public class BreadPartnersSDK: NSObject, UITextViewDelegate {
             placementsConfiguration: mutablePlacementsConfiguration,
             forSwiftUI: forSwiftUI,
             logger: logger,
-            showCaptcha: showCaptcha,
             callback: callback
         )
     }

--- a/Sources/BreadPartnersSDK/BreadPartnersSDK.swift
+++ b/Sources/BreadPartnersSDK/BreadPartnersSDK.swift
@@ -101,6 +101,7 @@ public class BreadPartnersSDK: NSObject, UITextViewDelegate {
         placementsConfiguration: PlacementConfiguration,
         splitTextAndAction: Bool = false,
         forSwiftUI: Bool = false,
+        showCaptcha: Bool = false,
         callback: @Sendable @escaping (
             BreadPartnerEvents
         ) -> Void
@@ -114,12 +115,18 @@ public class BreadPartnersSDK: NSObject, UITextViewDelegate {
         let logger = Logger()
         logger.setLogging(enabled: isLoggingEnabled)
         logger.setCallback(callback)
+        
+        // This will fetch reCaptcha keys if it was not done yet.
+        if (brandConfiguration == nil) {
+            await fetchBrandConfig(logger: logger)
+        }
             
         await executeSecurityCheck(
             merchantConfiguration: merchantConfiguration,
             placementsConfiguration: mutablePlacementsConfiguration,
             forSwiftUI: forSwiftUI,
             logger: logger,
+            showCaptcha: showCaptcha,
             callback: callback
         )
     }

--- a/Sources/BreadPartnersSDK/Core/Extensions/RTPSApiExtension.swift
+++ b/Sources/BreadPartnersSDK/Core/Extensions/RTPSApiExtension.swift
@@ -21,7 +21,6 @@ extension BreadPartnersSDK {
         placementsConfiguration: PlacementConfiguration,
         forSwiftUI: Bool = false,
         logger: Logger,
-        showCaptcha: Bool = false,
         callback: @Sendable @escaping (
             BreadPartnerEvents
         ) -> Void
@@ -44,7 +43,6 @@ extension BreadPartnersSDK {
                 forSwiftUI: forSwiftUI,
                 logger: logger,
                 callback: callback,
-                showCaptcha: showCaptcha,
                 token: token)
         } catch let error as RecaptchaError {
             print("Recaptcha Error: code \(error.errorCode), message \(error.errorMessage)")
@@ -68,7 +66,6 @@ extension BreadPartnersSDK {
         callback: @Sendable @escaping (
             BreadPartnerEvents
         ) -> Void,
-        showCaptcha: Bool = false,
         token: String
     ) async {
         do {
@@ -84,15 +81,11 @@ extension BreadPartnersSDK {
                 reCaptchaToken: token
             )
 
-            var headers: [String: String] = [
+            let headers: [String: String] = [
                 Constants.headerClientKey: integrationKey,
                 Constants.headerRequestedWithKey: Constants
                     .headerRequestedWithValue,
             ]
-            
-            if showCaptcha {
-                headers["X-Bread-Testing"] = "captcha"
-            }
 
             let rtpsRequestBuilt = requestBuilder.build()
 

--- a/Sources/BreadPartnersSDK/HTMLHandling/UIComponents/Popup/ChallengeController.swift
+++ b/Sources/BreadPartnersSDK/HTMLHandling/UIComponents/Popup/ChallengeController.swift
@@ -90,16 +90,12 @@ internal class ChallengeController: UIViewController, WKNavigationDelegate {
     // MARK: - WKNavigationDelegate
 
     func webView(_ webView: WKWebView, didFinish navigation: WKNavigation!) {
-        print("Olga: didFinish completed")
-        print("Olga: Current URL - \(webView.url?.absoluteString ?? "nil")")
-        
         if !hasInitialLoadCompleted {
             hasInitialLoadCompleted = true
         } else {
             // Challenge completed - check if we're back at original URL or got redirected
             if let currentURL = webView.url?.absoluteString,
                currentURL.contains(URL(string: originalURL)?.host ?? "") {
-                print("Olga: Challenge completed, dismissing and retrying")
                 
                 dismiss(animated: true) {
                     self.retryRequest?()

--- a/Sources/BreadPartnersSDK/HTMLHandling/UIComponents/Popup/ChallengeController.swift
+++ b/Sources/BreadPartnersSDK/HTMLHandling/UIComponents/Popup/ChallengeController.swift
@@ -1,0 +1,114 @@
+//------------------------------------------------------------------------------
+//  File:          ChallengeController.swift
+//  Author(s):     Bread Financial
+//  Date:          4 December 2025
+//
+//  Descriptions:  This file is part of the BreadPartnersSDK for iOS,
+//  providing UI components and functionalities to integrate Bread Financial
+//  services into partner applications.
+//
+//  © 2025 Bread Financial
+//------------------------------------------------------------------------------
+
+import WebKit
+
+internal class ChallengeController: UIViewController, WKNavigationDelegate {
+
+    private var webView: WKWebView!
+    private var closeButton: UIButton!
+    private let htmlContent: String
+    private let originalURL: String
+    private let callback: ((BreadPartnerEvents) -> Void)?
+    private let retryRequest: (() -> Void)?
+    private var hasInitialLoadCompleted = false
+
+    init(htmlContent: String, originalURL: String, callback: ((BreadPartnerEvents) -> Void)? = nil, retryRequest: (() -> Void)? = nil) {
+        self.htmlContent = htmlContent
+        self.originalURL = originalURL
+        self.callback = callback
+        self.retryRequest = retryRequest
+        super.init(nibName: nil, bundle: nil)
+    }
+
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+
+    override func viewDidLoad() {
+        super.viewDidLoad()
+        setupUI()
+        loadHTMLContent()
+    }
+
+    private func setupUI() {
+        view.backgroundColor = .white
+
+        closeButton = UIButton(type: .system)
+        closeButton.setTitle("✕", for: .normal)
+        closeButton.titleLabel?.font = .systemFont(ofSize: 24)
+        closeButton.addTarget(self, action: #selector(closeButtonTapped), for: .touchUpInside)
+        closeButton.translatesAutoresizingMaskIntoConstraints = false
+        view.addSubview(closeButton)
+
+        let config = WKWebViewConfiguration()
+        let preferences = WKWebpagePreferences()
+        preferences.allowsContentJavaScript = true
+        config.defaultWebpagePreferences = preferences
+
+        webView = WKWebView(frame: .zero, configuration: config)
+        webView.navigationDelegate = self
+        webView.translatesAutoresizingMaskIntoConstraints = false
+
+        if #available(iOS 16.4, *) {
+            webView.isInspectable = true
+        }
+
+        view.addSubview(webView)
+
+        NSLayoutConstraint.activate([
+            closeButton.topAnchor.constraint(equalTo: view.safeAreaLayoutGuide.topAnchor, constant: 10),
+            closeButton.trailingAnchor.constraint(equalTo: view.trailingAnchor, constant: -10),
+            closeButton.widthAnchor.constraint(equalToConstant: 44),
+            closeButton.heightAnchor.constraint(equalToConstant: 44),
+
+            webView.topAnchor.constraint(equalTo: closeButton.bottomAnchor, constant: 10),
+            webView.leadingAnchor.constraint(equalTo: view.leadingAnchor),
+            webView.trailingAnchor.constraint(equalTo: view.trailingAnchor),
+            webView.bottomAnchor.constraint(equalTo: view.bottomAnchor)
+        ])
+    }
+
+    private func loadHTMLContent() {
+        webView.loadHTMLString(htmlContent, baseURL: URL(string: originalURL))
+    }
+
+    @objc private func closeButtonTapped() {
+        callback?(.popupClosed)
+        dismiss(animated: true)
+    }
+
+    // MARK: - WKNavigationDelegate
+
+    func webView(_ webView: WKWebView, didFinish navigation: WKNavigation!) {
+        print("Olga: didFinish completed")
+        print("Olga: Current URL - \(webView.url?.absoluteString ?? "nil")")
+        
+        if !hasInitialLoadCompleted {
+            hasInitialLoadCompleted = true
+        } else {
+            // Challenge completed - check if we're back at original URL or got redirected
+            if let currentURL = webView.url?.absoluteString,
+               currentURL.contains(URL(string: originalURL)?.host ?? "") {
+                print("Olga: Challenge completed, dismissing and retrying")
+                
+                dismiss(animated: true) {
+                    self.retryRequest?()
+                }
+            }
+        }
+    }
+
+    func webView(_ webView: WKWebView, didFail navigation: WKNavigation!, withError error: Error) {
+        print("ChallengeController: Navigation failed - \(error.localizedDescription)")
+    }
+}

--- a/Sources/BreadPartnersSDK/Networking/APIClient.swift
+++ b/Sources/BreadPartnersSDK/Networking/APIClient.swift
@@ -138,6 +138,35 @@ internal class APIClient: @unchecked Sendable {
                         "Server returned an error: \(httpResponse.statusCode)"
                 ])
         }
+        
+        // Check content type before attempting JSON parsing
+        let contentType = httpResponse.value(forHTTPHeaderField: "Content-Type") ?? ""
+        guard contentType.contains("application/json") else {
+            let responseString = String(data: data, encoding: .utf8) ?? "Unable to decode response"
+
+            // Check if this is an Incapsula challenge page
+            if responseString.contains("_Incapsula_Resource") || responseString.contains("incap_ses") {
+                print("Security challenge detected")
+
+                // Return a structured error that can be handled by the caller
+                throw NSError(
+                    domain: "IncapsulaChallenge",
+                    code: 403,
+                    userInfo: [
+                        NSLocalizedDescriptionKey: "Security challenge detected. User interaction required.",
+                        "htmlContent": responseString,
+                        "url": urlString
+                    ])
+            }
+
+            throw NSError(
+                domain: "InvalidContentType",
+                code: 415,
+                userInfo: [
+                    NSLocalizedDescriptionKey: "Server returned \(contentType) instead of JSON.",
+                    "responseBody": responseString
+                ])
+        }
 
         // Decode the response data
         do {


### PR DESCRIPTION
When Captcha challenge is returned while making RTPS call response is not in JSON format. That was not what SDK expected and caused flow to be interrupted. Added ChallengeController to handle that scenario and display a pop up with Challenge. After user completes the challenge RTPS call is made again (that is handled by SDK, so no changes required from SDK users).