### PR TITLE
Add batch prescreen flow and optimize reCaptcha validation

### DIFF
--- a/Sources/BreadPartnersSDK/BreadPartnersSDK.swift
+++ b/Sources/BreadPartnersSDK/BreadPartnersSDK.swift
@@ -139,9 +139,11 @@ public class BreadPartnersSDK: NSObject, UITextViewDelegate {
             await fetchBrandConfig(logger: logger)
         }
             
-        await executeSecurityCheck(
+        await rtpsCall(
             merchantConfiguration: merchantConfiguration,
             placementsConfiguration: mutablePlacementsConfiguration,
+            splitTextAndAction: splitTextAndAction,
+            openPlacementExperience: false,
             forSwiftUI: forSwiftUI,
             logger: logger,
             callback: callback

--- a/Sources/BreadPartnersSDK/Core/Extensions/RTPSApiExtension.swift
+++ b/Sources/BreadPartnersSDK/Core/Extensions/RTPSApiExtension.swift
@@ -100,7 +100,7 @@ extension BreadPartnersSDK {
                 try await CommonUtils().decodeJSON(
                     from: response, to: RTPSResponse.self
                 )
-            let returnResultType = preScreenLookupResponse.returnCode
+            let returnResultType = preScreenLookupResponse.returnCodeString
             let prescreenResult = getPrescreenResult(
                 from: returnResultType ?? "10")
             placementsConfiguration.rtpsData!.prescreenId =
@@ -110,7 +110,7 @@ extension BreadPartnersSDK {
             /// Since this call runs in the background without user interaction,
             /// if the result is not "approved" or prescreenId is nill,
             /// we simply return without taking any further action.
-            if prescreenResult != .approved
+            if (prescreenResult != .approved && prescreenResult != .accountFound)
                 || placementsConfiguration.rtpsData?.prescreenId == nil
             {
                 return

--- a/Sources/BreadPartnersSDK/Core/Extensions/RTPSApiExtension.swift
+++ b/Sources/BreadPartnersSDK/Core/Extensions/RTPSApiExtension.swift
@@ -89,6 +89,7 @@ extension BreadPartnersSDK {
                       let locality = billingAddress?.locality, !locality.isEmpty,
                       let region = billingAddress?.region, !region.isEmpty,
                       let postalCode = billingAddress?.postalCode, !postalCode.isEmpty else {
+                    logger.printLog("Buyer information is missing or wrong.")
                     return callback(
                         .sdkError(
                             error: NSError(
@@ -111,6 +112,7 @@ extension BreadPartnersSDK {
                 )
             } else {
                 reCaptchaToken = nil
+                logger.printLog("Skipping reCaptcha token generation for virtual lookup call.")
             }
             
             let apiUrl = APIUrl(
@@ -146,27 +148,24 @@ extension BreadPartnersSDK {
             let prescreenResult = getPrescreenResult(
                 from: returnResultType ?? "10")
             
-            // Map response data back to configurations.
-            placementsConfiguration.rtpsData!.prescreenId =
-                preScreenLookupResponse.prescreenId
-            placementsConfiguration.rtpsData?.cardType = preScreenLookupResponse.cardType
-            
-            let updatedMerchantConfiguration = preScreenLookupResponse.updateMerchantConfiguration(merchantConfiguration)
-            
-            logger.printLog("PreScreenID:Result: \(prescreenResult )")
-
             // Since this call runs in the background without user interaction,
             // if the result is not "approved"(in case of regular prescreen call) and not "account found" (in case of lookup call)
             // or prescreenId is nill (in case user is approved, but already has an account),
             // we simply return without taking any further action.
             if (prescreenResult != .approved && prescreenResult != .accountFound)
-                || placementsConfiguration.rtpsData?.prescreenId == nil
+                || preScreenLookupResponse.prescreenId == nil
             {
                 return
             }
+            
+            // Map response data back to configurations.
+            placementsConfiguration.rtpsData!.prescreenId =
+                preScreenLookupResponse.prescreenId
+            placementsConfiguration.rtpsData?.cardType = preScreenLookupResponse.cardType
+            logger.printLog("PreScreenID:Result: \(prescreenResult )")
 
             await fetchRTPSData(
-                merchantConfiguration: updatedMerchantConfiguration,
+                merchantConfiguration: preScreenLookupResponse.updateMerchantConfiguration(merchantConfiguration),
                 placementsConfiguration: placementsConfiguration,
                 splitTextAndAction: splitTextAndAction,
                 openPlacementExperience: openPlacementExperience,

--- a/Sources/BreadPartnersSDK/Core/Extensions/RTPSApiExtension.swift
+++ b/Sources/BreadPartnersSDK/Core/Extensions/RTPSApiExtension.swift
@@ -69,7 +69,19 @@ extension BreadPartnersSDK {
         token: String
     ) async {
         do {
-
+            // Check for Batch Prescreen Flow when prescreen id has to be entered by user.
+            if (placementsConfiguration.rtpsData?.customerAcceptedOffer == true) {
+                return await fetchRTPSData(
+                    merchantConfiguration: merchantConfiguration,
+                    placementsConfiguration: placementsConfiguration,
+                    splitTextAndAction: splitTextAndAction,
+                    openPlacementExperience: openPlacementExperience,
+                    forSwiftUI: forSwiftUI,
+                    logger: logger,
+                    callback: callback)
+            }
+            
+            // Check if it is a regular RTPS flow or Batch Prescreen (prescreenId is known).
             let apiUrl = APIUrl(
                 urlType: placementsConfiguration.rtpsData?.prescreenId == nil
                     ? .prescreen : .virtualLookup
@@ -100,16 +112,23 @@ extension BreadPartnersSDK {
                 try await CommonUtils().decodeJSON(
                     from: response, to: RTPSResponse.self
                 )
-            let returnResultType = preScreenLookupResponse.returnCodeString
+            let returnResultType = preScreenLookupResponse.returnCode
             let prescreenResult = getPrescreenResult(
                 from: returnResultType ?? "10")
+            
+            // Map response data back to configurations.
             placementsConfiguration.rtpsData!.prescreenId =
                 preScreenLookupResponse.prescreenId
+            placementsConfiguration.rtpsData?.cardType = preScreenLookupResponse.cardType
+            
+            let updatedMerchantConfiguration = preScreenLookupResponse.updateMerchantConfiguration(merchantConfiguration)
+            
             logger.printLog("PreScreenID:Result: \(prescreenResult )")
 
-            /// Since this call runs in the background without user interaction,
-            /// if the result is not "approved" or prescreenId is nill,
-            /// we simply return without taking any further action.
+            // Since this call runs in the background without user interaction,
+            // if the result is not "approved"(in case of regular prescreen call) and not "account found" (in case of lookup call)
+            // or prescreenId is nill (in case user is approved, but already has an account),
+            // we simply return without taking any further action.
             if (prescreenResult != .approved && prescreenResult != .accountFound)
                 || placementsConfiguration.rtpsData?.prescreenId == nil
             {
@@ -117,7 +136,7 @@ extension BreadPartnersSDK {
             }
 
             await fetchRTPSData(
-                merchantConfiguration: merchantConfiguration,
+                merchantConfiguration: updatedMerchantConfiguration,
                 placementsConfiguration: placementsConfiguration,
                 splitTextAndAction: splitTextAndAction,
                 openPlacementExperience: openPlacementExperience,
@@ -181,12 +200,21 @@ extension BreadPartnersSDK {
         do {
             let apiUrl = APIUrl(urlType: .generatePlacements).url
 
-            let rtpsWebURL = await CommonUtils().buildRTPSWebURL(
-                integrationKey: integrationKey,
-                merchantConfiguration: merchantConfiguration,
-                rtpsData: placementsConfiguration.rtpsData!,
-                prescreenId: placementsConfiguration.rtpsData!.prescreenId
-            )?.absoluteString
+            let webURL: String?
+            if placementsConfiguration.rtpsData?.customerAcceptedOffer == true {
+                webURL = await CommonUtils().buildBpsWebURL(
+                    integrationKey: integrationKey,
+                    merchantConfiguration: merchantConfiguration,
+                    placementConfiguration: placementsConfiguration
+                )?.absoluteString
+            } else {
+                webURL = await CommonUtils().buildRTPSWebURL(
+                    integrationKey: integrationKey,
+                    merchantConfiguration: merchantConfiguration,
+                    rtpsData: placementsConfiguration.rtpsData!,
+                    prescreenId: placementsConfiguration.rtpsData!.prescreenId
+                )?.absoluteString
+            }
 
             let request = PlacementRequest(
                 placements: [
@@ -194,7 +222,7 @@ extension BreadPartnersSDK {
                         context: ContextRequestBody(
                             ENV: merchantConfiguration.env?.rawValue,
                             LOCATION: "RTPS-Approval",
-                            embeddedUrl: rtpsWebURL
+                            embeddedUrl: webURL
                         )
                     )
                 ], brandId: integrationKey

--- a/Sources/BreadPartnersSDK/Core/Extensions/RTPSApiExtension.swift
+++ b/Sources/BreadPartnersSDK/Core/Extensions/RTPSApiExtension.swift
@@ -16,47 +16,40 @@ import RecaptchaEnterprise
 extension BreadPartnersSDK {
     /// This method does bot behavior check using the Recaptcha v3 SDK,
     /// to protect against malicious attacks.
-    func executeSecurityCheck(
+    private func executeSecurityCheck(
         merchantConfiguration: MerchantConfiguration,
-        placementsConfiguration: PlacementConfiguration,
-        forSwiftUI: Bool = false,
-        logger: Logger,
-        callback: @Sendable @escaping (
-            BreadPartnerEvents
-        ) -> Void
-    ) async {
+        logger: Logger
+    ) async throws -> String {
         let siteKey = brandConfiguration?.config.getRecaptchaKey(
             for: merchantConfiguration.env ?? BreadPartnersEnvironment.prod
         )
 
-        do {
-            let token = try await RecaptchaManager.shared.executeReCaptcha(
-                siteKey: siteKey ?? "",
-                action: .init(customAction: "checkout"),
-                timeout: 10000,
-                debug: logger.isLoggingEnabled
-            )
-            await preScreenLookupCall(
-                merchantConfiguration: merchantConfiguration,
-                placementsConfiguration: placementsConfiguration,
-                splitTextAndAction: false, openPlacementExperience: false,
-                forSwiftUI: forSwiftUI,
-                logger: logger,
-                callback: callback,
-                token: token)
-        } catch let error as RecaptchaError {
-            print("Recaptcha Error: code \(error.errorCode), message \(error.errorMessage)")
-        } catch {
-            print("Unknown error: \(error)")
-        }
+        let token = try await RecaptchaManager.shared.executeReCaptcha(
+            siteKey: siteKey ?? "",
+            action: .init(customAction: "checkout"),
+            timeout: 10000,
+            debug: logger.isLoggingEnabled
+        )
+        
+        return token
     }
 
-    /// Once the Recaptcha token is obtained, make the pre-screen lookup API call.
-    /// - If  `prescreenId` was previously saved by the brand partner when calling the pre-screen endpoint,
-    ///      then trigger `virtualLookup`.
-    /// - Else call pre-screen endpoint to fetch `prescreenId`.
-    /// - Both endpoints require user details to build request payload.
-    private func preScreenLookupCall(
+    /// Makes RTPS (Real-Time Pre-Screen) API calls with conditional reCaptcha token validation.
+    ///
+    /// This method handles three different flows:
+    /// 1. **Batch Prescreen Flow**: When `customerAcceptedOffer` is true, skips RTPS and directly fetches placement data.
+    /// 2. **Prescreen Flow**: When `prescreenId` is nil, calls the prescreen endpoint with a reCaptcha token for bot protection.
+    /// 3. **Virtual Lookup Flow**: When `prescreenId` is known, calls the virtualLookup endpoint without a reCaptcha token.
+    ///
+    /// - Parameters:
+    ///   - merchantConfiguration: Merchant and buyer configuration details.
+    ///   - placementsConfiguration: Placement configuration including RTPS data.
+    ///   - splitTextAndAction: Whether to split text and action components.
+    ///   - openPlacementExperience: Whether to automatically open the placement experience.
+    ///   - forSwiftUI: Whether the view is for SwiftUI.
+    ///   - logger: Logger instance for tracking events.
+    ///   - callback: Callback to handle SDK events.
+    internal func rtpsCall(
         merchantConfiguration: MerchantConfiguration,
         placementsConfiguration: PlacementConfiguration,
         splitTextAndAction: Bool = false,
@@ -65,8 +58,7 @@ extension BreadPartnersSDK {
         logger: Logger,
         callback: @Sendable @escaping (
             BreadPartnerEvents
-        ) -> Void,
-        token: String
+        ) -> Void
     ) async {
         do {
             // Check for Batch Prescreen Flow when prescreen id has to be entered by user.
@@ -82,15 +74,53 @@ extension BreadPartnersSDK {
             }
             
             // Check if it is a regular RTPS flow or Batch Prescreen (prescreenId is known).
+            let isPrescreen = placementsConfiguration.rtpsData?.prescreenId == nil
+            
+            // Validate required fields for prescreen requests
+            if isPrescreen {
+                let buyer = merchantConfiguration.buyer
+                let billingAddress = buyer?.billingAddress
+                
+                // Check if firstname, lastname, and complete address are provided
+                guard let givenName = buyer?.givenName, !givenName.isEmpty,
+                      let familyName = buyer?.familyName, !familyName.isEmpty,
+                      let address1 = billingAddress?.address1, !address1.isEmpty,
+                      let country = billingAddress?.country, !country.isEmpty,
+                      let locality = billingAddress?.locality, !locality.isEmpty,
+                      let region = billingAddress?.region, !region.isEmpty,
+                      let postalCode = billingAddress?.postalCode, !postalCode.isEmpty else {
+                    return callback(
+                        .sdkError(
+                            error: NSError(
+                                domain: "", code: 400,
+                                userInfo: [
+                                    NSLocalizedDescriptionKey: Constants.prescreenRequiredFieldsError
+                                ]
+                            )
+                        )
+                    )
+                }
+            }
+            
+            // Only obtain reCaptcha token for prescreen requests
+            let reCaptchaToken: String?
+            if isPrescreen {
+                reCaptchaToken = try await executeSecurityCheck(
+                    merchantConfiguration: merchantConfiguration,
+                    logger: logger
+                )
+            } else {
+                reCaptchaToken = nil
+            }
+            
             let apiUrl = APIUrl(
-                urlType: placementsConfiguration.rtpsData?.prescreenId == nil
-                    ? .prescreen : .virtualLookup
+                urlType: isPrescreen ? .prescreen : .virtualLookup
             ).url
 
             let requestBuilder = RTPSRequestBuilder(
                 merchantConfiguration: merchantConfiguration,
                 rtpsData: placementsConfiguration.rtpsData!,
-                reCaptchaToken: token
+                reCaptchaToken: reCaptchaToken
             )
 
             let headers: [String: String] = [
@@ -157,11 +187,13 @@ extension BreadPartnersSDK {
                     callback: callback,
                     retryRequest: { [weak self] in
                         Task { @MainActor in
-                            // Restart from executeSecurityCheck to get fresh reCAPTCHA token
+                            // Restart from rtpsCall to get fresh reCAPTCHA token
                             // and clean WebKit process
-                            await self?.executeSecurityCheck(
+                            await self?.rtpsCall(
                                 merchantConfiguration: merchantConfiguration,
                                 placementsConfiguration: placementsConfiguration,
+                                splitTextAndAction: splitTextAndAction,
+                                openPlacementExperience: openPlacementExperience,
                                 forSwiftUI: forSwiftUI,
                                 logger: logger,
                                 callback: callback

--- a/Sources/BreadPartnersSDK/Core/Extensions/RTPSResponseExtension.swift
+++ b/Sources/BreadPartnersSDK/Core/Extensions/RTPSResponseExtension.swift
@@ -1,0 +1,72 @@
+//------------------------------------------------------------------------------
+//  File:          RTPSResponseExtension.swift
+//  Author(s):     Bread Financial
+//  Date:          17 March 2026
+//
+//  Descriptions:  This file is part of the BreadPartnersSDK for iOS,
+//  providing extension methods for mapping RTPSResponse data to configuration
+//  objects.
+//
+//  © 2026 Bread Financial
+//------------------------------------------------------------------------------
+
+import Foundation
+
+extension RTPSResponse {
+    /// Updates a MerchantConfiguration with buyer information from the RTPS response.
+    ///
+    /// This method creates an updated copy of the merchant configuration with buyer
+    /// information populated from the account lookup API response.
+    ///
+    /// - Parameter merchantConfiguration: The original merchant configuration.
+    /// - Returns: An updated MerchantConfiguration with buyer data from the response.
+    func updateMerchantConfiguration(_ merchantConfiguration: MerchantConfiguration) -> MerchantConfiguration {
+        var updatedConfig = merchantConfiguration
+        
+        // Create or update buyer information
+        var buyer = updatedConfig.buyer ?? BreadPartnersBuyer()
+        
+        if let firstName = self.firstName {
+            buyer.givenName = firstName
+        }
+        
+        if let lastName = self.lastName {
+            buyer.familyName = lastName
+        }
+        
+        if let middleInitial = self.middleInitial {
+            buyer.additionalName = middleInitial
+        }
+        
+        // Create or update billing address
+        if address1 != nil || city != nil || state != nil || zip != nil {
+            var billingAddress = buyer.billingAddress ?? BreadPartnersAddress(address1: "")
+            
+            if let address1 = self.address1 {
+                billingAddress.address1 = address1
+            }
+            
+            if let address2 = self.address2 {
+                billingAddress.address2 = address2
+            }
+            
+            if let city = self.city {
+                billingAddress.locality = city
+            }
+            
+            if let state = self.state {
+                billingAddress.region = state
+            }
+            
+            if let zip = self.zip {
+                billingAddress.postalCode = zip
+            }
+            
+            buyer.billingAddress = billingAddress
+        }
+        
+        updatedConfig.buyer = buyer
+        
+        return updatedConfig
+    }
+}

--- a/Sources/BreadPartnersSDK/Core/Models/PlacementConfiguration.swift
+++ b/Sources/BreadPartnersSDK/Core/Models/PlacementConfiguration.swift
@@ -17,7 +17,7 @@ import UIKit
 ///   - placementData: Defines text placements on the brand partner screen for the `registerPlacementFlow`.
 ///   - rtpsData: Specifies the real-time pre-screen configuration for the prescreen flow.
 ///   - popUpStyling: Configures the popup styling for each element rendered within the popup.
-public struct PlacementConfiguration {
+public struct PlacementConfiguration: @unchecked Sendable {
     public let placementData: PlacementData?
     public let rtpsData: RTPSData?
     public var popUpStyling: PopUpStyling?

--- a/Sources/BreadPartnersSDK/Core/Models/RTPSData.swift
+++ b/Sources/BreadPartnersSDK/Core/Models/RTPSData.swift
@@ -20,7 +20,7 @@ public class RTPSData: @unchecked Sendable {
     public var screenName: String?
     public var cardType: String?
     public var country: String?
-    public var prescreenId: Int?
+    public var prescreenId: Int64?
     public var correlationData: String?
     public var customerAcceptedOffer: Bool?
     public var channel: String?
@@ -31,7 +31,7 @@ public class RTPSData: @unchecked Sendable {
         financingType: BreadPartnersFinancingType? = nil, order: Order? = nil,
         locationType: BreadPartnersLocationType? = nil,
         screenName: String? = nil, cardType: String? = nil,
-        country: String? = nil, prescreenId: Int? = nil,
+        country: String? = nil, prescreenId: Int64? = nil,
         correlationData: String? = nil,
         customerAcceptedOffer: Bool? = nil, channel: String? = nil,
         subChannel: String? = nil,

--- a/Sources/BreadPartnersSDK/Networking/APIUrl.swift
+++ b/Sources/BreadPartnersSDK/Networking/APIUrl.swift
@@ -15,6 +15,7 @@ import Foundation
 /// Enum to define different types of API URLs.
 internal enum APIUrlType {
     case rtpsWebUrl(type: String)
+    case bpsWebUrl
     case brandStyle(brandId: String)
     case brandConfig(brandId: String)
     case generatePlacements
@@ -59,6 +60,8 @@ internal actor APIUrl {
         switch urlType {
         case .rtpsWebUrl(let type):
             return "\(rtpsBaseURL)/prescreen/\(type)"
+        case .bpsWebUrl:
+            return "\(rtpsBaseURL)/batch-prescreen/start"
         case .brandStyle(let brandId):
             return "\(baseURL)/brands/\(brandId)/style"
         case .brandConfig(let brandId):

--- a/Sources/BreadPartnersSDK/Networking/Models/RTPSRequest.swift
+++ b/Sources/BreadPartnersSDK/Networking/Models/RTPSRequest.swift
@@ -29,6 +29,7 @@ internal struct RTPSRequest: Codable {
     let mockResponse: String?
     let overrideConfig: OverrideConfig?
     let prescreenId: String?
+    let customerAcceptedOffer: Bool?
     let platform: String
     
     struct OverrideConfig: Codable {
@@ -50,7 +51,8 @@ internal struct RTPSRequest: Codable {
         reCaptchaToken: String? = nil,
         mockResponse: String? = nil,
         overrideConfig: OverrideConfig? = nil,
-        prescreenId: String? = nil
+        prescreenId: String? = nil,
+        customerAcceptedOffer: Bool? = nil
     ) {
         self.urlPath = urlPath
         self.firstName = firstName
@@ -67,6 +69,7 @@ internal struct RTPSRequest: Codable {
         self.mockResponse = mockResponse
         self.overrideConfig = overrideConfig
         self.prescreenId = prescreenId
+        self.customerAcceptedOffer = customerAcceptedOffer
         self.platform = "ios"
     }
 }

--- a/Sources/BreadPartnersSDK/Networking/Models/RTPSResponse.swift
+++ b/Sources/BreadPartnersSDK/Networking/Models/RTPSResponse.swift
@@ -39,7 +39,13 @@ func getPrescreenResult(from apiResponse: String) -> PrescreenResult {
 
 /// Represents the response model for an RTPS.
 struct RTPSResponse: Codable {
-    let returnCode: String?
-    let prescreenId: Int?
+    let returnCode: Int?
+    let prescreenId: Int64?
+    
+    /// Returns the returnCode as a String for mapping to PrescreenResult
+    var returnCodeString: String? {
+        guard let code = returnCode else { return nil }
+        return String(code)
+    }
 }
 

--- a/Sources/BreadPartnersSDK/Networking/Models/RTPSResponse.swift
+++ b/Sources/BreadPartnersSDK/Networking/Models/RTPSResponse.swift
@@ -39,13 +39,69 @@ func getPrescreenResult(from apiResponse: String) -> PrescreenResult {
 
 /// Represents the response model for an RTPS.
 struct RTPSResponse: Codable {
-    let returnCode: Int?
+    let returnCode: String?
     let prescreenId: Int64?
+    let firstName: String?
+    let middleInitial: String?
+    let lastName: String?
+    let address1: String?
+    let address2: String?
+    let city: String?
+    let state: String?
+    let zip: String?
+    let cardType: String?
+    let isExpired: Bool?
+    let hasExistingAccount: Bool?
+    let errorMessage: String?
+    let errorCode: Int?
     
-    /// Returns the returnCode as a String for mapping to PrescreenResult
-    var returnCodeString: String? {
-        guard let code = returnCode else { return nil }
-        return String(code)
+    enum CodingKeys: String, CodingKey {
+        case returnCode
+        case prescreenId
+        case firstName
+        case middleInitial
+        case lastName
+        case address1
+        case address2
+        case city
+        case state
+        case zip
+        case cardType
+        case isExpired
+        case hasExistingAccount
+        case errorMessage
+        case errorCode
+    }
+    
+    init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        
+        // Handle prescreenId as Int64
+        prescreenId = try container.decodeIfPresent(Int64.self, forKey: .prescreenId)
+        
+        // Handle returnCode as either String or Int, convert to String
+        if let returnCodeString = try? container.decode(String.self, forKey: .returnCode) {
+            returnCode = returnCodeString
+        } else if let returnCodeInt = try? container.decode(Int.self, forKey: .returnCode) {
+            returnCode = String(returnCodeInt)
+        } else {
+            returnCode = nil
+        }
+        
+        // Decode remaining fields
+        firstName = try container.decodeIfPresent(String.self, forKey: .firstName)
+        middleInitial = try container.decodeIfPresent(String.self, forKey: .middleInitial)
+        lastName = try container.decodeIfPresent(String.self, forKey: .lastName)
+        address1 = try container.decodeIfPresent(String.self, forKey: .address1)
+        address2 = try container.decodeIfPresent(String.self, forKey: .address2)
+        city = try container.decodeIfPresent(String.self, forKey: .city)
+        state = try container.decodeIfPresent(String.self, forKey: .state)
+        zip = try container.decodeIfPresent(String.self, forKey: .zip)
+        cardType = try container.decodeIfPresent(String.self, forKey: .cardType)
+        isExpired = try container.decodeIfPresent(Bool.self, forKey: .isExpired)
+        hasExistingAccount = try container.decodeIfPresent(Bool.self, forKey: .hasExistingAccount)
+        errorMessage = try container.decodeIfPresent(String.self, forKey: .errorMessage)
+        errorCode = try container.decodeIfPresent(Int.self, forKey: .errorCode)
     }
 }
 

--- a/Sources/BreadPartnersSDK/Networking/RequestBuilders/RTPSRequestBuilder.swift
+++ b/Sources/BreadPartnersSDK/Networking/RequestBuilders/RTPSRequestBuilder.swift
@@ -15,12 +15,12 @@ class RTPSRequestBuilder: @unchecked Sendable {
 
     private var merchantConfiguration: MerchantConfiguration
     private var rtpsData: RTPSData
-    private var token: String
+    private var token: String?
 
     init(
         merchantConfiguration: MerchantConfiguration,
         rtpsData: RTPSData,
-        reCaptchaToken: String
+        reCaptchaToken: String?
     ) {
         self.merchantConfiguration = merchantConfiguration
         self.rtpsData = rtpsData

--- a/Sources/BreadPartnersSDK/Networking/RequestBuilders/RTPSRequestBuilder.swift
+++ b/Sources/BreadPartnersSDK/Networking/RequestBuilders/RTPSRequestBuilder.swift
@@ -46,7 +46,8 @@ class RTPSRequestBuilder: @unchecked Sendable {
                 reCaptchaToken: token,
                 mockResponse: rtpsData.mockResponse?.rawValue,
                 overrideConfig: RTPSRequest.OverrideConfig(
-                    enhancedPresentment: true)
+                    enhancedPresentment: true),
+                customerAcceptedOffer: rtpsData.customerAcceptedOffer
             )
         } else {
             return RTPSRequest(
@@ -57,7 +58,8 @@ class RTPSRequestBuilder: @unchecked Sendable {
                 mockResponse: rtpsData.mockResponse?.rawValue,
                 overrideConfig: RTPSRequest.OverrideConfig(
                     enhancedPresentment: true),
-                prescreenId: String(rtpsData.prescreenId!)
+                prescreenId: String(rtpsData.prescreenId!),
+                customerAcceptedOffer: rtpsData.customerAcceptedOffer
             )
         }
 

--- a/Sources/BreadPartnersSDK/Utilities/CommonUtils.swift
+++ b/Sources/BreadPartnersSDK/Utilities/CommonUtils.swift
@@ -77,7 +77,7 @@ internal actor CommonUtils: NSObject {
         integrationKey: String,
         merchantConfiguration: MerchantConfiguration,
         rtpsData: RTPSData,
-        prescreenId: Int?
+        prescreenId: Int64?
     ) async -> URL? {
 
         let mockResponseValue = rtpsData.mockResponse?.rawValue

--- a/Sources/BreadPartnersSDK/Utilities/CommonUtils.swift
+++ b/Sources/BreadPartnersSDK/Utilities/CommonUtils.swift
@@ -122,6 +122,106 @@ internal actor CommonUtils: NSObject {
         return urlComponents.url
     }
 
+    /// Builds a URL for BPS (Batch Prescreen) Web based on the provided integration and configuration details.
+    /// - Parameters:
+    ///   - integrationKey: The unique integration key for the request.
+    ///   - merchantConfiguration: The merchant configuration containing buyer and merchant-specific data.
+    ///   - placementConfiguration: The placement configuration containing placement or RTPS data.
+    /// - Returns: A URL constructed with the given parameters, or nil if the URL could not be built.
+    func buildBpsWebURL(
+        integrationKey: String,
+        merchantConfiguration: MerchantConfiguration,
+        placementConfiguration: PlacementConfiguration
+    ) async -> URL? {
+
+        let mockResponseValue = placementConfiguration.rtpsData?.mockResponse?.rawValue
+        
+        // Extract buyer information
+        let buyer = merchantConfiguration.buyer
+        let billingAddress = buyer?.billingAddress
+        
+        // Extract order data from RTPS or placement data
+        let order = placementConfiguration.rtpsData?.order ?? placementConfiguration.placementData?.order
+        
+        // Extract location - prioritize RTPS location over placement location
+        let location = placementConfiguration.rtpsData?.locationType?.rawValue
+            ?? placementConfiguration.placementData?.locationType?.rawValue
+        
+        // Extract channel - prioritize RTPS channel over merchant channel
+        let channel = placementConfiguration.rtpsData?.channel ?? merchantConfiguration.channel
+        let subchannel = placementConfiguration.rtpsData?.subChannel ?? merchantConfiguration.subchannel
+        
+        let queryParams: [String: String?] = [
+            "mockMO": mockResponseValue.takeIfNotEmpty(),
+            "mockPA": mockResponseValue.takeIfNotEmpty(),
+            "mockVL": mockResponseValue.takeIfNotEmpty(),
+            "embedded": "true",
+            "clientKey": integrationKey,
+            "prescreenId": placementConfiguration.rtpsData?.prescreenId.map { String($0) },
+            "firstName": buyer?.givenName,
+            "middleInitial": buyer?.additionalName,
+            "lastName": buyer?.familyName,
+            "address1": billingAddress?.address1,
+            "address2": billingAddress?.address2,
+            "city": billingAddress?.locality,
+            "state": billingAddress?.region,
+            "zip": billingAddress?.postalCode,
+            "emailAddress": buyer?.email,
+            "mobilePhone": buyer?.phone,
+            "alternativePhone": buyer?.alternativePhone,
+            "cardType": placementConfiguration.rtpsData?.cardType,
+            "storeNumber": merchantConfiguration.storeNumber,
+            "loyaltyNumber": merchantConfiguration.loyaltyID,
+            "customerNumber": nil,
+            "cartAmount": order?.subTotal?.value.map { String($0) },
+            "productAmount": order?.items?.first?.unitPrice?.value.map { String($0) },
+            "checkoutAmount": order?.totalPrice?.value.map { String($0) },
+            "urlPath": nil,
+            "location": location,
+            "category": order?.items?.first?.category,
+            "sku": order?.items?.first?.sku,
+            "correlationData": placementConfiguration.rtpsData?.correlationData,
+            "epId": nil,
+            "epPlacementId": nil,
+            "epSessionId": nil,
+            "epMessageId": nil,
+            "channel": channel,
+            "subchannel": subchannel,
+            "clientVariable1": merchantConfiguration.clientVariable1,
+            "clientVariable2": merchantConfiguration.clientVariable2,
+            "clientVariable3": merchantConfiguration.clientVariable3,
+            "clientVariable4": merchantConfiguration.clientVariable4,
+            "selectedCardKey": placementConfiguration.placementData?.selectedCardKey,
+            "defaultSelectedCardKey": placementConfiguration.placementData?.defaultSelectedCardKey,
+            "departmentId": merchantConfiguration.departmentId,
+            "overrideKey": merchantConfiguration.overrideKey,
+            "cardChoiceCode": nil,
+            "associateId": merchantConfiguration.clerkId,
+            "carrier": nil,
+            "keyword": nil,
+            "shortCode": nil,
+            "channelId": nil,
+            "applicationSubType": nil,
+            "splitPayment": nil
+        ]
+        
+        guard
+            var urlComponents = URLComponents(
+                string: APIUrl(urlType: .bpsWebUrl).url)
+        else {
+            return nil
+        }
+
+        await Task {
+            urlComponents.queryItems = queryParams.compactMap { key, value in
+                guard let value = value, !value.isEmpty else { return nil }
+                return URLQueryItem(name: key, value: value)
+            }
+        }.value
+
+        return urlComponents.url
+    }
+
     @MainActor func getUserAgent() -> String {
         let systemName = UIDevice.current.systemName  // e.g., "iOS"
         let systemVersion = UIDevice.current.systemVersion  // e.g., "17.2"

--- a/Sources/BreadPartnersSDK/Utilities/Constants.swift
+++ b/Sources/BreadPartnersSDK/Utilities/Constants.swift
@@ -50,7 +50,7 @@ internal class Constants{
     
     static let securityCheckAlertAcknolwedgeMessage = "Your web view will load once the captcha verification is successfully completed. This ensures that all transactions are secure."
     
-    static func securityCheckAlertFailedMessage(error:String) -> String {        
+    static func securityCheckAlertFailedMessage(error:String) -> String {
         return "Error: \(error)"
     }
     
@@ -72,6 +72,8 @@ internal class Constants{
     static let popupPlacementParsingError = "\(error) Unable to parse popup placement."
     static let missingPopupPlacementError = "Unhandled popup placement type."
     static let somethingWentWrong = "Something went wrong. Please try again later."
+    
+    static let prescreenRequiredFieldsError = "Error: Prescreen requires customer information: firstname, lastname, and complete billing address must be provided in MerchantConfiguration."
 
     static func unableToLoadWebURL(message:String)->String{
         return  "\(error) Web Url Loading Issue: \(message)"


### PR DESCRIPTION
# Pull Request: Batch Prescreen Flow Implementation

## 🎯 Overview
Implements **Batch Prescreen Flow** for pre-approved customers, optimizes reCaptcha usage, and adds input validation for RTPS requests.

---

## ✨ Key Features

### 1. Batch Prescreen Flow
Enables pre-approved customers to complete applications without re-screening.
- When `customerAcceptedOffer = true`, skips RTPS and uses batch prescreen URL
- New `buildBpsWebURL()` method for URL construction
- Supports account lookup to retrieve customer information

### 2. Account Lookup Integration  
Automatically populates buyer information from API responses.
- New `RTPSResponseExtension.swift` with `updateMerchantConfiguration()` method
- Enhanced `RTPSResponse` model with customer data fields (name, address, cardType, etc.)

### 3. Conditional reCaptcha (Security Optimization)
Improves performance by only requiring reCaptcha when needed:
- ✅ **Prescreen**: Requires reCaptcha (new users, bot protection)
- ❌ **Virtual Lookup**: Skips reCaptcha (existing prescreenId)
- ❌ **Batch Prescreen**: Skips reCaptcha (pre-approved)

### 4. Prescreen Input Validation
Validates required buyer fields before API calls:
- First name, last name, and complete billing address (address1, country, locality, region, postalCode)
- Returns error 400 if validation fails
- Prevents unnecessary API calls

---

## 🔄 Key API Changes

### Models
- `RTPSData.prescreenId`: `Int` → `Int64`
- `RTPSData.customerAcceptedOffer`: New `Bool?` field
- `RTPSResponse`: Added 12+ new fields for account lookup
- `PlacementConfiguration`: Added `@unchecked Sendable` conformance

### Methods
- `executeSecurityCheck()`: Now `private`, returns `String` token, throws errors
- `preScreenLookupCall()` → `rtpsCall()`: Renamed, `internal` visibility, handles all flows
- `RTPSResponse.updateMerchantConfiguration()`: New method for mapping response data
- `CommonUtils.buildBpsWebURL()`: New method for batch prescreen URLs

### Flow Decision Logic
```
customerAcceptedOffer = true? → Batch Prescreen (skip RTPS)
prescreenId = nil? → Prescreen (validate + reCaptcha)
prescreenId exists? → Virtual Lookup (skip validation + reCaptcha)
```