### PR TITLE
Preserve HTML Formatting for NO_ACTION Text Placements

### DIFF
--- a/Sources/BreadPartnersSDK/HTMLHandling/Extensions/TextPlacementUIHandler.swift
+++ b/Sources/BreadPartnersSDK/HTMLHandling/Extensions/TextPlacementUIHandler.swift
@@ -56,35 +56,7 @@ extension HTMLContentRenderer {
                 mutableAttributedString.removeAttribute(.link, range: range)
                 mutableAttributedString.removeAttribute(.underlineStyle, range: range)
                 
-                // Apply configurable font sizes while preserving formatting (bold, superscript, etc.)
-                let baseFontSize: CGFloat = 18.0 // Default base font size
-                let superscriptFontSize: CGFloat = 12.0 // Default superscript font size
-                
-                mutableAttributedString.enumerateAttributes(in: range, options: []) { attributes, attrRange, _ in
-                    // Check if this is superscript by looking for baseline offset
-                    let baselineOffset = attributes[.baselineOffset] as? NSNumber
-                    let isSuperscript = (baselineOffset?.floatValue ?? 0) > 0
-                    
-                    if let currentFont = attributes[.font] as? UIFont {
-                        // Use smaller size for superscript, regular size for normal text
-                        let newSize = isSuperscript ? superscriptFontSize : baseFontSize
-                        
-                        // Preserve font traits (bold, italic)
-                        let fontDescriptor = currentFont.fontDescriptor
-                        let newFontDescriptor = fontDescriptor.withSize(newSize)
-                        let newFont = UIFont(descriptor: newFontDescriptor, size: newSize)
-                        
-                        mutableAttributedString.addAttribute(.font, value: newFont, range: attrRange)
-                    } else {
-                        // If no font attribute, add default font
-                        let defaultSize = isSuperscript ? superscriptFontSize : baseFontSize
-                        let defaultFont = UIFont.systemFont(ofSize: defaultSize)
-                        mutableAttributedString.addAttribute(.font, value: defaultFont, range: attrRange)
-                    }
-                }
-                
                 if forSwiftUI {
-                    // Use the new initializer that accepts attributed string to preserve HTML formatting
                     let swiftUIView = BreadPartnerLinkTextSwitUI(
                         attributedString: mutableAttributedString,
                         onTap: {
@@ -95,7 +67,6 @@ extension HTMLContentRenderer {
                     )
                     self.callback(.renderSwiftUITextViewWithLink(textView: swiftUIView))
                 } else {
-                    // For UIKit, use BreadPartnerLinkText with HTML attributed string
                     let textView = BreadPartnerLinkText()
                     textView.configure(with: mutableAttributedString) { [self] _ in
                         Task {
@@ -131,7 +102,6 @@ extension HTMLContentRenderer {
             return
         }
 
-        // Original logic for other action types with clickable links
         if actionLink.isEmpty {
             actionLink = contentText
             contentText = ""

--- a/Sources/BreadPartnersSDK/HTMLHandling/Extensions/TextPlacementUIHandler.swift
+++ b/Sources/BreadPartnersSDK/HTMLHandling/Extensions/TextPlacementUIHandler.swift
@@ -44,38 +44,61 @@ extension HTMLContentRenderer {
         let actionType = textPlacementModel?.actionType
         let htmlContent = textPlacementModel?.htmlContent
 
-        // For NO_ACTION type, render as formatted HTML text that's NOT clickable
+        // For NO_ACTION type, render as formatted HTML text that's clickable (triggers textClicked callback)
         if actionType == PlacementActionType.noAction.rawValue,
            let htmlString = htmlContent, !htmlString.isEmpty {
             
             if forSwiftUI {
-                // For SwiftUI, convert HTML to attributed string and render as plain text
+                // For SwiftUI, convert HTML to attributed string and render as tappable text
                 if let attributedString = htmlString.htmlToAttributedString() {
-                    let swiftUIView = BreadPartnerTextView(attributedString.string)
+                    // Use the plain text without HTML tags, no links array (empty)
+                    let swiftUIView = BreadPartnerLinkTextSwitUI(
+                        attributedString.string,
+                        links: [], // No links to underline
+                        onTap: {
+                            Task {
+                                await self.handleLinkInteraction(link: "")
+                            }
+                        }
+                    )
                     self.callback(.renderSwiftUITextViewWithLink(textView: swiftUIView))
                 } else {
                     // Fallback to plain text if HTML conversion fails
-                    let swiftUIView = BreadPartnerTextView(contentText)
+                    let swiftUIView = BreadPartnerLinkTextSwitUI(
+                        contentText,
+                        links: [],
+                        onTap: {
+                            Task {
+                                await self.handleLinkInteraction(link: "")
+                            }
+                        }
+                    )
                     self.callback(.renderSwiftUITextViewWithLink(textView: swiftUIView))
                 }
             } else {
-                // For UIKit, use plain UITextView with HTML attributed string (non-interactive)
-                let textView = UITextView()
-                textView.isEditable = false
-                textView.isScrollEnabled = false
-                textView.isSelectable = false // Make it non-interactive
-                textView.backgroundColor = .clear
+                // For UIKit, use BreadPartnerLinkText with HTML attributed string
+                let textView = BreadPartnerLinkText()
                 
                 if let attributedString = htmlString.htmlToAttributedString() {
-                    // Create a mutable copy to remove any existing link attributes
+                    // Create a mutable copy to remove any link attributes and underlines
                     let mutableAttributedString = NSMutableAttributedString(attributedString: attributedString)
                     let range = NSRange(location: 0, length: mutableAttributedString.length)
                     mutableAttributedString.removeAttribute(.link, range: range)
+                    mutableAttributedString.removeAttribute(.underlineStyle, range: range)
                     
-                    textView.attributedText = mutableAttributedString
+                    textView.configure(with: mutableAttributedString) { [self] _ in
+                        Task {
+                            await handleLinkInteraction(link: "")
+                        }
+                    }
                 } else {
                     // Fallback to plain text if HTML conversion fails
-                    textView.text = contentText
+                    let plainAttributedString = NSAttributedString(string: contentText)
+                    textView.configure(with: plainAttributedString) { [self] _ in
+                        Task {
+                            await handleLinkInteraction(link: "")
+                        }
+                    }
                 }
                 
                 self.callback(.renderTextViewWithLink(textView: textView))

--- a/Sources/BreadPartnersSDK/HTMLHandling/Extensions/TextPlacementUIHandler.swift
+++ b/Sources/BreadPartnersSDK/HTMLHandling/Extensions/TextPlacementUIHandler.swift
@@ -48,13 +48,45 @@ extension HTMLContentRenderer {
         if actionType == PlacementActionType.noAction.rawValue,
            let htmlString = htmlContent, !htmlString.isEmpty {
             
-            if forSwiftUI {
-                // For SwiftUI, convert HTML to attributed string and render as tappable text
-                if let attributedString = htmlString.htmlToAttributedString() {
-                    // Use the plain text without HTML tags, no links array (empty)
+            // Convert HTML to attributed string
+            if let attributedString = htmlString.htmlToAttributedString() {
+                // Create a mutable copy to remove any link attributes and underlines
+                let mutableAttributedString = NSMutableAttributedString(attributedString: attributedString)
+                let range = NSRange(location: 0, length: mutableAttributedString.length)
+                mutableAttributedString.removeAttribute(.link, range: range)
+                mutableAttributedString.removeAttribute(.underlineStyle, range: range)
+                
+                // Apply configurable font sizes while preserving formatting (bold, superscript, etc.)
+                let baseFontSize: CGFloat = 18.0 // Default base font size
+                let superscriptFontSize: CGFloat = 12.0 // Default superscript font size
+                
+                mutableAttributedString.enumerateAttributes(in: range, options: []) { attributes, attrRange, _ in
+                    // Check if this is superscript by looking for baseline offset
+                    let baselineOffset = attributes[.baselineOffset] as? NSNumber
+                    let isSuperscript = (baselineOffset?.floatValue ?? 0) > 0
+                    
+                    if let currentFont = attributes[.font] as? UIFont {
+                        // Use smaller size for superscript, regular size for normal text
+                        let newSize = isSuperscript ? superscriptFontSize : baseFontSize
+                        
+                        // Preserve font traits (bold, italic)
+                        let fontDescriptor = currentFont.fontDescriptor
+                        let newFontDescriptor = fontDescriptor.withSize(newSize)
+                        let newFont = UIFont(descriptor: newFontDescriptor, size: newSize)
+                        
+                        mutableAttributedString.addAttribute(.font, value: newFont, range: attrRange)
+                    } else {
+                        // If no font attribute, add default font
+                        let defaultSize = isSuperscript ? superscriptFontSize : baseFontSize
+                        let defaultFont = UIFont.systemFont(ofSize: defaultSize)
+                        mutableAttributedString.addAttribute(.font, value: defaultFont, range: attrRange)
+                    }
+                }
+                
+                if forSwiftUI {
+                    // Use the new initializer that accepts attributed string to preserve HTML formatting
                     let swiftUIView = BreadPartnerLinkTextSwitUI(
-                        attributedString.string,
-                        links: [], // No links to underline
+                        attributedString: mutableAttributedString,
                         onTap: {
                             Task {
                                 await self.handleLinkInteraction(link: "")
@@ -63,7 +95,18 @@ extension HTMLContentRenderer {
                     )
                     self.callback(.renderSwiftUITextViewWithLink(textView: swiftUIView))
                 } else {
-                    // Fallback to plain text if HTML conversion fails
+                    // For UIKit, use BreadPartnerLinkText with HTML attributed string
+                    let textView = BreadPartnerLinkText()
+                    textView.configure(with: mutableAttributedString) { [self] _ in
+                        Task {
+                            await handleLinkInteraction(link: "")
+                        }
+                    }
+                    self.callback(.renderTextViewWithLink(textView: textView))
+                }
+            } else {
+                // Fallback to plain text if HTML conversion fails
+                if forSwiftUI {
                     let swiftUIView = BreadPartnerLinkTextSwitUI(
                         contentText,
                         links: [],
@@ -74,34 +117,16 @@ extension HTMLContentRenderer {
                         }
                     )
                     self.callback(.renderSwiftUITextViewWithLink(textView: swiftUIView))
-                }
-            } else {
-                // For UIKit, use BreadPartnerLinkText with HTML attributed string
-                let textView = BreadPartnerLinkText()
-                
-                if let attributedString = htmlString.htmlToAttributedString() {
-                    // Create a mutable copy to remove any link attributes and underlines
-                    let mutableAttributedString = NSMutableAttributedString(attributedString: attributedString)
-                    let range = NSRange(location: 0, length: mutableAttributedString.length)
-                    mutableAttributedString.removeAttribute(.link, range: range)
-                    mutableAttributedString.removeAttribute(.underlineStyle, range: range)
-                    
-                    textView.configure(with: mutableAttributedString) { [self] _ in
-                        Task {
-                            await handleLinkInteraction(link: "")
-                        }
-                    }
                 } else {
-                    // Fallback to plain text if HTML conversion fails
+                    let textView = BreadPartnerLinkText()
                     let plainAttributedString = NSAttributedString(string: contentText)
                     textView.configure(with: plainAttributedString) { [self] _ in
                         Task {
                             await handleLinkInteraction(link: "")
                         }
                     }
+                    self.callback(.renderTextViewWithLink(textView: textView))
                 }
-                
-                self.callback(.renderTextViewWithLink(textView: textView))
             }
             return
         }

--- a/Sources/BreadPartnersSDK/HTMLHandling/Extensions/TextPlacementUIHandler.swift
+++ b/Sources/BreadPartnersSDK/HTMLHandling/Extensions/TextPlacementUIHandler.swift
@@ -42,7 +42,48 @@ extension HTMLContentRenderer {
         var contentText = textPlacementModel?.contentText ?? ""
         var actionLink = textPlacementModel?.actionLink ?? ""
         let actionType = textPlacementModel?.actionType
+        let htmlContent = textPlacementModel?.htmlContent
 
+        // For NO_ACTION type, render as formatted HTML text that's NOT clickable
+        if actionType == PlacementActionType.noAction.rawValue,
+           let htmlString = htmlContent, !htmlString.isEmpty {
+            
+            if forSwiftUI {
+                // For SwiftUI, convert HTML to attributed string and render as plain text
+                if let attributedString = htmlString.htmlToAttributedString() {
+                    let swiftUIView = BreadPartnerTextView(attributedString.string)
+                    self.callback(.renderSwiftUITextViewWithLink(textView: swiftUIView))
+                } else {
+                    // Fallback to plain text if HTML conversion fails
+                    let swiftUIView = BreadPartnerTextView(contentText)
+                    self.callback(.renderSwiftUITextViewWithLink(textView: swiftUIView))
+                }
+            } else {
+                // For UIKit, use plain UITextView with HTML attributed string (non-interactive)
+                let textView = UITextView()
+                textView.isEditable = false
+                textView.isScrollEnabled = false
+                textView.isSelectable = false // Make it non-interactive
+                textView.backgroundColor = .clear
+                
+                if let attributedString = htmlString.htmlToAttributedString() {
+                    // Create a mutable copy to remove any existing link attributes
+                    let mutableAttributedString = NSMutableAttributedString(attributedString: attributedString)
+                    let range = NSRange(location: 0, length: mutableAttributedString.length)
+                    mutableAttributedString.removeAttribute(.link, range: range)
+                    
+                    textView.attributedText = mutableAttributedString
+                } else {
+                    // Fallback to plain text if HTML conversion fails
+                    textView.text = contentText
+                }
+                
+                self.callback(.renderTextViewWithLink(textView: textView))
+            }
+            return
+        }
+
+        // Original logic for other action types with clickable links
         if actionLink.isEmpty {
             actionLink = contentText
             contentText = ""

--- a/Sources/BreadPartnersSDK/HTMLHandling/HTMLContentParser.swift
+++ b/Sources/BreadPartnersSDK/HTMLHandling/HTMLContentParser.swift
@@ -30,6 +30,9 @@ internal actor HTMLContentParser {
         let actionType = try document.select("[data-action-type]").attr(
             "data-action-type")
 
+        // Extract HTML content (preserving formatting)
+        let htmlContentWithFormatting = try document.select(".ep-text-placement").html()
+
         // Extract text content
         let actionLink = try document.select(".epjs-body-action a").text()
         let contentText =
@@ -63,7 +66,8 @@ internal actor HTMLContentParser {
             actionTarget: actionTarget.isEmpty ? nil : actionTarget,
             contentText: finalContentText.isEmpty ? nil : finalContentText,
             actionLink: actionLink.isEmpty ? nil : actionLink,
-            actionContentId: actionContentId.isEmpty ? nil : actionContentId
+            actionContentId: actionContentId.isEmpty ? nil : actionContentId,
+            htmlContent: htmlContentWithFormatting.isEmpty ? nil : htmlContentWithFormatting
         )
     }
 

--- a/Sources/BreadPartnersSDK/HTMLHandling/UIComponents/BreadPartnerLinkText.swift
+++ b/Sources/BreadPartnersSDK/HTMLHandling/UIComponents/BreadPartnerLinkText.swift
@@ -15,6 +15,7 @@ import UIKit
 /// A custom UITextView for displaying tappable link-styled text in Bread Partner UI.
 public class BreadPartnerLinkText: UITextView {
     private var tapHandler: ((String) -> Void)?
+    private var allowTapWithoutLink: Bool = false
 
     override init(frame: CGRect, textContainer: NSTextContainer?) {
         super.init(frame: frame, textContainer: textContainer)
@@ -43,6 +44,18 @@ public class BreadPartnerLinkText: UITextView {
     ) {
         self.attributedText = attributedText
         self.tapHandler = tapHandler
+        
+        // Check if the attributed string has any .link attributes
+        var hasLinkAttribute = false
+        attributedText.enumerateAttribute(.link, in: NSRange(location: 0, length: attributedText.length)) { value, _, stop in
+            if value != nil {
+                hasLinkAttribute = true
+                stop.pointee = true
+            }
+        }
+        
+        // If no link attributes found, allow tap anywhere on the text
+        self.allowTapWithoutLink = !hasLinkAttribute
     }
 
     @objc private func handleTap(_ gesture: UITapGestureRecognizer) {
@@ -80,7 +93,16 @@ public class BreadPartnerLinkText: UITextView {
                 Task {
                     await handleLinkTap(link)
                 }
-
+            } else if allowTapWithoutLink {
+                // For NO_ACTION text without link attributes, trigger tap handler with empty string
+                Task {
+                    await handleLinkTap("")
+                }
+            }
+        } else if allowTapWithoutLink {
+            // Tapped outside text bounds but still within view - trigger for NO_ACTION
+            Task {
+                await handleLinkTap("")
             }
         }
     }

--- a/Sources/BreadPartnersSDK/HTMLHandling/UIComponents/BreadPartnerLinkTextSwitUI.swift
+++ b/Sources/BreadPartnersSDK/HTMLHandling/UIComponents/BreadPartnerLinkTextSwitUI.swift
@@ -21,6 +21,7 @@ public struct BreadPartnerLinkTextSwitUI: View {
     private var linkColor: Color
     private var linkFontName: String
     private var linkFontSize: CGFloat
+    private var attributedText: NSAttributedString?
 
     public init(
         _ text: String, links: [String] = [], onTap: (() -> Void)? = nil,
@@ -32,43 +33,57 @@ public struct BreadPartnerLinkTextSwitUI: View {
         self.linkColor = .blue
         self.linkFontName = fontName
         self.linkFontSize = fontSize
+        self.attributedText = nil
+    }
+    
+    /// Initializer for attributed string (with HTML formatting preserved)
+    public init(
+        attributedString: NSAttributedString, onTap: (() -> Void)? = nil
+    ) {
+        self.text = attributedString.string
+        self.links = []
+        self.onTap = onTap
+        self.linkColor = .blue
+        self.linkFontName = "System"
+        self.linkFontSize = 17
+        self.attributedText = attributedString
     }
 
     public var body: some View {
-        let attributedString = NSMutableAttributedString(string: text)
-                let fullRange = NSRange(location: 0, length: attributedString.length)
-                attributedString.addAttribute(.font, value: fontToUIFont(fontName: linkFontName, size: linkFontSize), range: fullRange)
+        // Use provided attributedText if available (for HTML formatted content)
+        let finalAttributedString: NSAttributedString
         
-        var emptyAttributedString: NSAttributedString
-
-                    if #available(iOS 15, *) {
-                        emptyAttributedString = NSAttributedString("")
-                    } else {
-                        emptyAttributedString = NSAttributedString(string: "")
-                    }
-        
-        var nsText: NSString
-        
-        nsText = NSString(string: text)
-
-        for word in links {
-            let wordRange = nsText.range(of: word)
-            if wordRange.location != NSNotFound {
-                attributedString.addAttribute(.foregroundColor, value: colorToUIColor(linkColor), range: wordRange)
-                attributedString.addAttribute(.underlineStyle, value: NSUnderlineStyle.single.rawValue, range: wordRange)
-                attributedString.addAttribute(.font, value: fontToUIFont(fontName: linkFontName, size: linkFontSize), range: wordRange)
+        if let providedAttributedText = attributedText {
+            finalAttributedString = providedAttributedText
+        } else {
+            // Build attributed string from plain text and links
+            let attributedString = NSMutableAttributedString(string: text)
+            let fullRange = NSRange(location: 0, length: attributedString.length)
+            attributedString.addAttribute(.font, value: fontToUIFont(fontName: linkFontName, size: linkFontSize), range: fullRange)
+            
+            let nsText = NSString(string: text)
+            
+            for word in links {
+                let wordRange = nsText.range(of: word)
+                if wordRange.location != NSNotFound {
+                    attributedString.addAttribute(.foregroundColor, value: colorToUIColor(linkColor), range: wordRange)
+                    attributedString.addAttribute(.underlineStyle, value: NSUnderlineStyle.single.rawValue, range: wordRange)
+                    attributedString.addAttribute(.font, value: fontToUIFont(fontName: linkFontName, size: linkFontSize), range: wordRange)
+                }
             }
+            
+            finalAttributedString = attributedString
         }
 
         if #available(iOS 15.0, *) {
             return AnyView(
-                Text(AttributedString(attributedString))
+                Text(AttributedString(finalAttributedString))
                     .onTapGesture { onTap?() }
                     .padding()
             )
         } else {
             return AnyView(
-                UILabelRepresentable(attributedText: attributedString, onTap: onTap)
+                UILabelRepresentable(attributedText: finalAttributedString, onTap: onTap)
                     .padding()
             )
         }

--- a/Sources/BreadPartnersSDK/HTMLHandling/UIComponents/Models/TextPlacementModel.swift
+++ b/Sources/BreadPartnersSDK/HTMLHandling/UIComponents/Models/TextPlacementModel.swift
@@ -17,6 +17,7 @@ internal struct TextPlacementModel {
     let contentText: String?
     let actionLink: String?
     let actionContentId: String?
+    let htmlContent: String?
 }
 
 /// Enum representing the different action types associated with a placement.
@@ -26,5 +27,5 @@ internal enum PlacementActionType: String {
     case breadApply = "BREAD_APPLY"
     case redirectInternal = "REDIRECT_INTERNAL"
     case versatileEco = "VERSATILE_ECO"
-    case noAction = "NO_ACTION"    
+    case noAction = "NO_ACTION"
 }

--- a/Sources/BreadPartnersSDK/Utilities/Extensions.swift
+++ b/Sources/BreadPartnersSDK/Utilities/Extensions.swift
@@ -71,3 +71,21 @@ extension Optional where Wrapped == String {
         return self
     }
 }
+
+extension String {
+    /// Converts an HTML string to NSAttributedString with formatting preserved
+    func htmlToAttributedString() -> NSAttributedString? {
+        guard let data = self.data(using: .utf8) else { return nil }
+        
+        do {
+            let options: [NSAttributedString.DocumentReadingOptionKey: Any] = [
+                .documentType: NSAttributedString.DocumentType.html,
+                .characterEncoding: String.Encoding.utf8.rawValue
+            ]
+            
+            return try NSAttributedString(data: data, options: options, documentAttributes: nil)
+        } catch {
+            return nil
+        }
+    }
+}

--- a/Sources/BreadPartnersSDK/Utilities/Logger.swift
+++ b/Sources/BreadPartnersSDK/Utilities/Logger.swift
@@ -162,6 +162,9 @@ internal class Logger: NSObject, @unchecked Sendable {
         lines.append("Content Text      : \(model.contentText ?? "N/A")")
         lines.append("Action Link       : \(model.actionLink ?? "N/A")")
         lines.append("Action Content ID : \(model.actionContentId ?? "N/A")")
+        if let htmlContent = model.htmlContent {
+            lines.append("HTML Content      : \(htmlContent)")
+        }
         lines.append("\(dashLineFifty)\n")
         
         let message = lines.joined(separator: "\n")


### PR DESCRIPTION
# Fix HTML Formatting for NO_ACTION Text Placements

## Problem
NO_ACTION text placements with HTML formatting (bold, superscript, etc.) displayed as link with no formatting preserved from html.

**Example:** `Pay as low as <strong>$102/mo</strong>...<sup>^</sup>` rendered without formatting.

## Solution
Convert HTML to AttributedString to preserve formatting for NO_ACTION placements in both SwiftUI and UIKit.

- TextPlacementUIHandler - Unified NO_ACTION rendering with HTML support
- BreadPartnerLinkTextSwitUI - New initializer for NSAttributedString
- BreadPartnerLinkText - Added tap support without link attributes
- HTMLContentParser - Preserve htmlContent field
- Extensions - Added htmlToAttributedString() helper
- TextPlacementModel - Added htmlContent field
- Logger - Added HTML logging

## Result

✅ HTML formatting (bold, italic, superscript) displays correctly  
✅ Text is clickable and triggers textClicked callback  
✅ Works for both SwiftUI and UIKit  
✅ Fully backward compatible